### PR TITLE
[Day1] 다리 만들기(2146)_김우헌

### DIFF
--- a/baekjoon/2146/2146_김우헌.py
+++ b/baekjoon/2146/2146_김우헌.py
@@ -1,0 +1,53 @@
+'''
+baekjoon g3 다리만들기
+https://www.acmicpc.net/problem/2146
+'''
+
+from collections import deque, defaultdict
+from itertools import combinations, product
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+matrix = []
+for _ in range(N):
+    matrix.append(list(map(int, input().split())))
+
+visit =[[False for _ in range(N)] for _ in range(N)]
+country = defaultdict(set)
+country_num = 1
+dx = [0, 1, -1, 0]
+dy = [1, 0, 0, -1]
+
+# 국가 구분
+for r in range(N):
+    for c in range(N):
+        if visit[r][c] == False and matrix[r][c] == 1:
+            q = deque()
+            q.append((r, c))
+            visit[r][c] = True
+            while q:
+                x, y = q.popleft()
+                for i in range(4):
+                    nx = x + dx[i]
+                    ny = y + dy[i]
+                    if 0 <= nx < N and 0 <= ny < N and visit[nx][ny] == False:
+                        if matrix[nx][ny] == 1:
+                            visit[nx][ny] = True
+                            q.append((nx, ny))
+                        elif matrix[nx][ny] == 0:
+                            country[country_num].add((x, y))
+            country_num += 1
+
+min_answer = float('inf')
+country_mapping_set = combinations(country.values(), 2)
+
+for c1, c2 in country_mapping_set:
+    for p1 in c1:
+        for p2 in c2:
+            min_answer = min(min_answer, abs(p1[0]-p2[0]) + abs(p1[1]-p2[1]) - 1)
+# for c1, c2 in country_mapping_set:
+#     bridge_mapping_set = product(c1, c2)
+#     curr = min([abs(p1[0]-p2[0]) + abs(p1[1]-p2[1]) - 1 for p1, p2 in bridge_mapping_set])
+#     min_answer = min(min_answer, curr)
+print(min_answer)


### PR DESCRIPTION
1. BFS 탐색을 통해 나라를 구분하고, country 사전에 나라의 경계면 좌표를 넣습니다.
  경계면 좌표가 중복으로 들어가는 것을 방지하기 위해 defaultdict를 통해 set으로 초기화한 사전을 사용합니다.
2. 생성된 나라별 경계면 좌표를 combination을 사용해 두개씩 묶어 각 나라간 최소 길이를 구합니다.

국가 구분을 BFS를 통해 진행했는데, pypy가 아닌 python3로 제출하면 시간초과가 납니다. 이유가 궁금하네요.
그리고 itertools.product를 사용해 두 나라의 좌표를 모두 묶어 한번에 계산하고자 했는데 이또한 시간초과가 났었습니다.