### PR TITLE
[Day3] 퇴사 2(15486)_김은서

### DIFF
--- a/baekjoon/15486/15486_김은서.py
+++ b/baekjoon/15486/15486_김은서.py
@@ -1,0 +1,26 @@
+"""
+퇴사(https://www.acmicpc.net/problem/15486)
+풀이: dp
+"""
+
+import sys
+
+input = sys.stdin.readline
+
+
+def solution(N, schedule):
+    dp = [0 for _ in range(N + 1)]
+    for i, [day, profit] in enumerate(schedule):
+        if i + day <= N:
+            dp[i + day] = max(dp[i] + profit, dp[i + day])  # i일에 상담을 하는 경우 & 안하는 경우 비교
+        dp[i + 1] = max(dp[i], dp[i + 1])  # 이익은 계속 누적되므로 값을 갱신시켜야 함
+
+    return dp[-1]
+
+
+N = int(input())
+schedule = []
+for _ in range(N):
+    schedule.append(list(map(int, input().split())))
+result = solution(N, schedule)
+print(result)


### PR DESCRIPTION
i일에 대해
- i일에 상담을 하는 경우
- i일에 상담을 안하는 경우

를 비교하여 [i일까지 상담을 진행했을때의 최대 이익]을 dp에 저장합니다.

즉, dp의 i번째 자리값은 [i일까지 상담을 진행했을때의 최대 이익]입니다.
이익은 계속 누적되어야 하므로 매번 다음날(i+1)의 값을 갱신시켰습니다. (`dp[i + 1] = max(dp[i], dp[i + 1])`)
예를 들어서 다음과 같은 입력이 있을 때
```
3
1 100
1 100
3 10
```
dp는 다음과 같이 [0, 100, 200, 200]이 됩니다.
이때, 3일째 되는 날에는 아무 상담도 진행하지 않지만, 이익은 계속 누적되어야 하므로
2일째 되는 날의 값을 그대로 가져와서 dp[3]에 저장했습니다.

이런식으로 구하면 `dp[i]`를 통해 `i번째 일까지 일했을때 최대 이익`을 구할 수 있습니다.
따라서 퇴사일의 최대 수익은 dp의 맨 마지막 값, `dp[-1]`이 정답이 됩니다.


제가 dp를 잘 못해서🥹 한번 차근차근 정리해보았읍니다...