### PR TITLE
[Day6] 트리와 쿼리(15681)_김은서

### DIFF
--- a/baekjoon/15681/15681_김은서.py
+++ b/baekjoon/15681/15681_김은서.py
@@ -1,0 +1,49 @@
+"""
+트리와 쿼리(https://www.acmicpc.net/problem/15681)
+
+풀이
+루트(R)부터 리프노드까지 dfs로 탐색하기
+→ 만약 더 이상 자식 노드가 없는 리프노드에 도달하면 리턴
+→ 리턴되면서 차례대로 현재 노드를 루트로 하는 서브트리와 연결된 노드 수 갱신하기
+"""
+
+from collections import defaultdict
+import sys
+
+sys.setrecursionlimit(10**6)
+
+input = sys.stdin.readline
+
+
+N, R, Q = map(int, input().split())
+graph = defaultdict(set)
+for _ in range(N - 1):
+    a, b = map(int, input().split())
+    graph[a].add(b)
+    graph[b].add(a)
+
+vertex_count = [0 for _ in range(N + 1)]
+visited = defaultdict(set)  # 자식 노드 방문 여부를 체크하는 visited
+
+
+def dfs(node, graph):
+    global visited
+
+    children = graph[node]
+    total_vertex_count = 1  # total_vertex_count: 현재 node가 루트인 서브트리의 모든 정점의 수
+    for child_node in children:
+        if child_node not in visited[node]:
+            visited[node].add(child_node)
+            visited[child_node].add(node)  # 양방향 그래프이므로 반대 경우도 처리해주어야 함
+            total_vertex_count += dfs(child_node, graph)
+
+    vertex_count[node] = total_vertex_count
+
+    return total_vertex_count
+
+
+dfs(R, graph)
+
+for _ in range(Q):
+    root = int(input())
+    print(vertex_count[root])


### PR DESCRIPTION
### 풀이
1. 루트부터 리프노드까지 dfs로 쭉 탐색합니다.
    > 이때 방문 여부를 체크하기 위해 visited를 만들었습니다.
    graph가 양방향 그래프이므로 부모↔︎자식 양쪽에 대해서 모두 처리해줘야 됩니다.
2. 리프노드에 도달한 경우 `total_vertex_count(=현재 노드가 root인 서브 트리의 모든 정점 개수)`는 1입니다.
그리고 더이상 탐색이 불가능하므로 `total_vertex_count`를 리턴합니다.
3. 재귀가 종료되면 이제 리프노드부터 루트까지 리턴되면서 다시 역으로 올라갑니다.
이때 리턴값을 다시 현재 노드의 `total_vertex_count`에 더해서 갱신시켜줍니다.
따라서 리프부터 루트까지 역으로 올라가면서 모든 노드에 대한 `total_vertex_count`를 `vertex_count` 배열에 저장했습니다.
4. 이렇게 모두 구하면 최종적으로 `vertex_count[i]`는 `(i+1)번 노드를 root로 하는 서브트리의 정점 개수`입니다.🥹