### PR TITLE
[Day9] 접두사 찾기(14426)_김우헌

### DIFF
--- a/baekjoon/14426/14426_김우헌.py
+++ b/baekjoon/14426/14426_김우헌.py
@@ -1,0 +1,22 @@
+import sys
+from collections import defaultdict
+
+input = sys.stdin.readline
+
+
+N, M = map(int, input().split())
+
+string_dict = defaultdict(list)
+for _ in range(N):
+    s = input().rstrip()
+    string_dict[s[0]].append(s)
+
+ans = 0
+for _ in range(M):
+    p = input().rstrip()
+    for s in string_dict[p[0]]:
+        if s[:len(p)] == p:
+            ans += 1
+            break
+print(ans)
+    


### PR DESCRIPTION
1. N개의 문자열 집합을 문자열 첫글자를 기준으로 해시테이블을 만듭니다.
2. 각 접두사 M에 대해서 접두사 M의 첫글자인 사전으로 들어가
    접두사가 M인 문자열이 존재하는지 확인하고 있다면 카운트를 증가시킵니다.